### PR TITLE
Getting scheme and host from headers from proxies

### DIFF
--- a/src/DibsEasyCheckout.cs
+++ b/src/DibsEasyCheckout.cs
@@ -134,7 +134,11 @@ namespace Dynamicweb.Ecommerce.CheckoutHandlers.DibsEasyCheckout
             {
                 var baseUrl = SystemConfiguration.Instance.GetValue("/Globalsettings/System/http/BaseUrl");
                 if (string.IsNullOrEmpty(baseUrl))
-                    baseUrl = $"{Context.Current.Request.Url.Scheme}://{Context.Current.Request.Url.Host}{portString}";
+                {
+                    var scheme = Context.Current.Request.Headers.Get("X-Forwarded-Proto") ?? Context.Current.Request.Url.Scheme;
+                    var host = Context.Current.Request.Headers.Get("X-Forwarded-Host") ?? Context.Current.Request.Url.Host;
+                    baseUrl = $"{scheme}://{host}{portString}";
+                }
 
                 var url = $"{baseUrl}/dwapi/ecommerce/carts/callback?{OrderIdRequestName}={order.Id}";
                 return url;

--- a/src/Dynamicweb.Ecommerce.CheckoutHandlers.DibsEasyCheckout.csproj
+++ b/src/Dynamicweb.Ecommerce.CheckoutHandlers.DibsEasyCheckout.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>10.0.4</VersionPrefix>
+		<VersionPrefix>10.0.5</VersionPrefix>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Description>DibsEasyCheckout</Description>
 	</PropertyGroup>


### PR DESCRIPTION
When dealing with reverse proxies we can use the standards to get the scheme and host for the originating point.

[AB#14782](https://dev.azure.com/dynamicwebsoftware/5a2edd81-7d89-4716-a4f3-1187ba91af92/_workitems/edit/14782)