### PR TITLE
Fix for the nicped-patch-1 PR

### DIFF
--- a/src/DibsEasyCheckout.cs
+++ b/src/DibsEasyCheckout.cs
@@ -109,9 +109,9 @@ namespace Dynamicweb.Ecommerce.CheckoutHandlers.DibsEasyCheckout
         {
             LogEvent(order, "Checkout started");
 
-
+            bool headless = parameters is not null;
             var formTemplate = new Template(TemplateHelper.GetTemplatePath(PostTemplate, PostTemplateFolder));
-            return RenderPaymentForm(order, formTemplate, true, parameters?.ReceiptUrl);
+            return RenderPaymentForm(order, formTemplate, headless, parameters?.ReceiptUrl);
         }
 
         protected override string GetBaseUrl(Order order, bool headless = false)

--- a/src/Dynamicweb.Ecommerce.CheckoutHandlers.DibsEasyCheckout.csproj
+++ b/src/Dynamicweb.Ecommerce.CheckoutHandlers.DibsEasyCheckout.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>10.6.0</VersionPrefix>
+		<VersionPrefix>10.6.1</VersionPrefix>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Nets Easy Checkout</Title>
 		<Description>Nets Easy Checkout</Description>


### PR DESCRIPTION
It looks like that we are in the headless context if CheckoutParameters are not null. This fix should restore right behavior.
Original PR is here: https://github.com/dynamicweb/CheckoutHandlers.DibsEasyCheckout/pull/15